### PR TITLE
Escape the Pattern special character before passing to string.gsub()

### DIFF
--- a/classes/fontproof.lua
+++ b/classes/fontproof.lua
@@ -256,6 +256,7 @@ SILE.registerCommand("basic", function (_, content)
     end
     local newcont = ""
     for r = 1, #gitems do
+      if gitems[r] == "%" then gitems[r] = "%%" end
       local newstr = string.gsub(cont, char, gitems[r])
       newcont = newcont .. char .. newstr
     end


### PR DESCRIPTION
This will fix #17. It's not pretty, but Lua doesn't seem to have a way to disable patterns in `string.gsub()`. The `string.find()` function can be forced to use plain strings with no patterns, but the only way I found to do substitution involved escaping the input.

Since the input is in a `*.sil` document as one big long string then split by character, there is no way to enter the escape there. SILE itself gets the `%` character just fine, but since it's sending everything a character at a time to `gsub()` any escaping is lost. This injects the necessary escape at the last possible second.